### PR TITLE
Add storm tracker feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
 # tailtrailgrail
+
+A simple map-based dashboard using Leaflet and public APIs. It currently includes dashboards for:
+
+- Real-Time Weather
+- Air Quality (AQI)
+- Storm Tracker
+
+Open `index.html` in a browser to explore the map and dashboards.

--- a/index.html
+++ b/index.html
@@ -160,6 +160,7 @@
 
     <script src="weather.js"></script>
     <script src="aqi.js"></script>
+    <script src="storm.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             // --- MAP INITIALIZATION ---
@@ -256,6 +257,9 @@
                 } else if (dashboardTitle === 'Air Quality (AQI)') {
                     hideOverlay();
                     activateAQI(map, infoBox, overlayEl);
+                } else if (dashboardTitle === 'Storm Tracker') {
+                    hideOverlay();
+                    activateStormTracker(map, infoBox, overlayEl);
                 } else {
                     hideOverlay();
                     infoBox.update({

--- a/storm.js
+++ b/storm.js
@@ -1,0 +1,65 @@
+// Fetch active weather alerts from the US National Weather Service
+function fetchStormAlerts() {
+    const url = 'https://api.weather.gov/alerts/active';
+    return fetch(url, {
+        headers: {
+            'Accept': 'application/geo+json'
+        }
+    }).then(r => r.json());
+}
+
+function showStormAlerts(map, alerts) {
+    if (map.stormLayer) {
+        map.removeLayer(map.stormLayer);
+    }
+    map.stormLayer = L.geoJSON(alerts, {
+        style: {
+            color: 'orange',
+            weight: 2,
+            fillOpacity: 0.2
+        },
+        onEachFeature: function(feature, layer) {
+            const props = feature.properties || {};
+            const event = props.event || 'Alert';
+            const headline = props.headline || '';
+            layer.bindPopup(`<strong>${event}</strong><br>${headline}`);
+        }
+    }).addTo(map);
+}
+
+function activateStormTracker(map, infoBox, overlay) {
+    fetchStormAlerts()
+        .then(data => {
+            const features = data.features || [];
+            if (features.length > 0) {
+                showStormAlerts(map, features);
+                infoBox.update({
+                    title: 'Storm Tracker',
+                    description: `Showing ${features.length} active alerts.`
+                });
+                if (overlay) {
+                    overlay.innerHTML = `Active alerts: ${features.length}`;
+                    overlay.classList.remove('hidden');
+                }
+            } else {
+                infoBox.update({ title: 'Storm Tracker', description: 'No active alerts found.' });
+                if (overlay) {
+                    overlay.innerHTML = 'No active alerts found.';
+                    overlay.classList.remove('hidden');
+                }
+            }
+        })
+        .catch(() => {
+            infoBox.update({ title: 'Storm Tracker', description: 'Failed to load storm data.' });
+            if (overlay) {
+                overlay.innerHTML = 'Failed to load storm data.';
+                overlay.classList.remove('hidden');
+            }
+        });
+
+    if (overlay) {
+        overlay.classList.remove('hidden');
+    }
+}
+
+window.activateStormTracker = activateStormTracker;


### PR DESCRIPTION
## Summary
- document the available dashboards
- add Storm Tracker scripts
- show active storm alerts using weather.gov API

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686ee185c8b08324aa2b870efd9113f8