### PR TITLE
Improve storm tracker alerts with distance check

### DIFF
--- a/storm.js
+++ b/storm.js
@@ -27,18 +27,92 @@ function showStormAlerts(map, alerts) {
     }).addTo(map);
 }
 
+function toRad(deg) {
+    return deg * (Math.PI / 180);
+}
+
+function haversineDistance(lat1, lon1, lat2, lon2) {
+    const R = 3958.8; // Radius of Earth in miles
+    const dLat = toRad(lat2 - lat1);
+    const dLon = toRad(lon2 - lon1);
+    const a = Math.sin(dLat / 2) ** 2 + Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) ** 2;
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+    return R * c;
+}
+
+function getFeatureCoordinates(feature) {
+    const geom = feature.geometry;
+    if (!geom) return [];
+    const coords = [];
+
+    function pushCoord(c) {
+        if (Array.isArray(c) && c.length >= 2) {
+            coords.push([c[1], c[0]]); // [lat, lon]
+        }
+    }
+
+    if (geom.type === 'Point') {
+        pushCoord(geom.coordinates);
+    } else if (geom.type === 'Polygon') {
+        geom.coordinates.forEach(ring => ring.forEach(pushCoord));
+    } else if (geom.type === 'MultiPolygon') {
+        geom.coordinates.forEach(poly => poly.forEach(ring => ring.forEach(pushCoord)));
+    } else if (geom.type === 'LineString') {
+        geom.coordinates.forEach(pushCoord);
+    } else if (geom.type === 'MultiLineString') {
+        geom.coordinates.forEach(line => line.forEach(pushCoord));
+    }
+
+    return coords;
+}
+
+function distanceToFeature(feature, lat, lon) {
+    const coords = getFeatureCoordinates(feature);
+    let min = Infinity;
+    for (const [clat, clon] of coords) {
+        const d = haversineDistance(lat, lon, clat, clon);
+        if (d < min) min = d;
+    }
+    return min;
+}
+
+function nearestAlertDistance(features, lat, lon) {
+    let min = Infinity;
+    for (const feature of features) {
+        const d = distanceToFeature(feature, lat, lon);
+        if (d < min) min = d;
+    }
+    return min;
+}
+
 function activateStormTracker(map, infoBox, overlay) {
+    const center = map.getCenter();
     fetchStormAlerts()
         .then(data => {
             const features = data.features || [];
             if (features.length > 0) {
                 showStormAlerts(map, features);
+
+                const nearest = nearestAlertDistance(features, center.lat, center.lng);
+
+                let status = '✅ No Threat';
+                let desc = 'No storm alerts within a 50 mile radius.';
+
+                if (nearest <= 25) {
+                    status = '❗ High Alert';
+                    desc = `Nearest storm alert is ${nearest.toFixed(1)} miles away.`;
+                } else if (nearest <= 50) {
+                    status = '⚠️ Low Threat';
+                    desc = `Nearest storm alert is ${nearest.toFixed(1)} miles away.`;
+                }
+
                 infoBox.update({
                     title: 'Storm Tracker',
-                    description: `Showing ${features.length} active alerts.`
+                    description: `${status} ${desc}`
                 });
+
                 if (overlay) {
-                    overlay.innerHTML = `Active alerts: ${features.length}`;
+                    overlay.innerHTML = `${status} ${desc}`;
                     overlay.classList.remove('hidden');
                 }
             } else {


### PR DESCRIPTION
## Summary
- compute geodesic distance to each storm alert
- classify alerts as High Alert, Low Threat, or No Threat based on proximity
- display nearest alert information in the info box and overlay

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fde3431308324a4ac6bed5aa253e3