### PR TITLE
Enable dashboard toggle and fix fullscreen cleanup

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,13 +109,18 @@
                 <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 9V4.5h4.5M15 4.5H19.5V9M4.5 15V19.5h4.5M15 19.5H19.5V15" />
             </svg>
         </button>
+        <button id="dashboard-toggle-btn" class="bg-gray-700 hover:bg-gray-600 p-2 rounded-full transition-colors ml-2" title="Toggle Dashboard">
+            <svg class="w-6 h-6" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                <path stroke-linecap="round" stroke-linejoin="round" d="M3.75 5.25h16.5M3.75 12h16.5M3.75 18.75h16.5" />
+            </svg>
+        </button>
     </header>
 
     <!-- Main Content -->
     <main class="flex-grow container mx-auto p-4 grid grid-cols-1 md:grid-cols-3 lg:grid-cols-4 gap-4">
         
         <!-- Left Column: Control Panel -->
-        <aside class="md:col-span-1 lg:col-span-1 bg-gray-800 p-4 rounded-lg shadow-lg flex flex-col space-y-6 h-full">
+        <aside id="dashboard-pane" class="md:col-span-1 lg:col-span-1 bg-gray-800 p-4 rounded-lg shadow-lg flex flex-col space-y-6 h-full">
             <div class="flex justify-between items-center">
                 <h2 class="text-xl font-semibold">Dashboards</h2>
                 <button id="my-location-btn" class="bg-gray-700 hover:bg-gray-600 p-2 rounded-full transition-colors" title="Find My Location">
@@ -166,7 +171,7 @@
         </aside>
 
         <!-- Right Column: Map Container -->
-        <div class="md:col-span-2 lg:col-span-3 bg-gray-800 rounded-lg shadow-lg overflow-hidden h-[60vh] md:h-auto">
+        <div id="map-section" class="md:col-span-2 lg:col-span-3 bg-gray-800 rounded-lg shadow-lg overflow-hidden h-[60vh] md:h-auto">
             <div id="map-container" class="relative w-full h-full">
                 <div id="map" class="w-full h-full"></div>
                 <div id="map-overlay" class="absolute inset-0 flex items-center justify-center pointer-events-none bg-black bg-opacity-50 text-white text-xl font-semibold hidden"></div>
@@ -189,6 +194,9 @@
             const map = L.map('map').setView([40.7128, -74.0060], 5);
             const overlayEl = document.getElementById('map-overlay');
             const fullscreenBtn = document.getElementById('fullscreen-btn');
+            const dashboardPane = document.getElementById("dashboard-pane");
+            const dashboardToggleBtn = document.getElementById("dashboard-toggle-btn");
+            const mapSection = document.getElementById("map-section");
             function hideOverlay() {
                 overlayEl.classList.add('hidden');
             }
@@ -209,6 +217,29 @@
             }
 
             fullscreenBtn.addEventListener('click', toggleFullScreen);
+            function toggleDashboard() {
+                if (dashboardPane.classList.contains("hidden")) {
+                    dashboardPane.classList.remove("hidden");
+                    mapSection.classList.remove("md:col-span-3", "lg:col-span-4");
+                    mapSection.classList.add("md:col-span-2", "lg:col-span-3");
+                } else {
+                    dashboardPane.classList.add("hidden");
+                    mapSection.classList.remove("md:col-span-2", "lg:col-span-3");
+                    mapSection.classList.add("md:col-span-3", "lg:col-span-4");
+                }
+                map.invalidateSize();
+            }
+
+            dashboardToggleBtn.addEventListener("click", toggleDashboard);
+
+            document.addEventListener("fullscreenchange", () => {
+                if (!document.fullscreenElement) {
+                    document.body.classList.remove("map-fullscreen");
+                } else {
+                    document.body.classList.add("map-fullscreen");
+                }
+                map.invalidateSize();
+            });
 
             L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
                 maxZoom: 19,


### PR DESCRIPTION
## Summary
- add a dashboard toggle button in the header
- allow the dashboard pane to be shown or hidden
- adjust map layout when the pane is toggled
- restore layout when exiting fullscreen via `fullscreenchange` event

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6882f0d88f508324a83c64801cf358cc