### PR TITLE
Add satellite explorer functionality

### DIFF
--- a/index.html
+++ b/index.html
@@ -185,6 +185,7 @@
     <script src="weather.js"></script>
     <script src="aqi.js"></script>
     <script src="storm.js"></script>
+    <script src="satellite.js"></script>
     <script>
         document.addEventListener('DOMContentLoaded', () => {
             // --- MAP INITIALIZATION ---
@@ -193,6 +194,7 @@
             const fullscreenBtn = document.getElementById('fullscreen-btn');
             function hideOverlay() {
                 overlayEl.classList.add('hidden');
+                overlayEl.classList.add('pointer-events-none');
             }
 
             map.on('click', hideOverlay);
@@ -310,6 +312,9 @@
                 } else if (dashboardTitle === 'Storm Tracker') {
                     hideOverlay();
                     activateStormTracker(map, infoBox, overlayEl);
+                } else if (dashboardTitle === 'Satellite Explorer') {
+                    hideOverlay();
+                    activateSatelliteExplorer(map, infoBox, overlayEl);
                 } else {
                     hideOverlay();
                     infoBox.update({

--- a/satellite.js
+++ b/satellite.js
@@ -1,0 +1,46 @@
+const SATELLITE_LAYERS = {
+    esri: {
+        url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
+        attribution: '&copy; <a href="https://www.esri.com/">Esri</a>'
+    },
+    usgs: {
+        url: 'https://basemap.nationalmap.gov/ArcGIS/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}',
+        attribution: 'Tiles courtesy of the <a href="https://usgs.gov/">USGS</a>'
+    }
+};
+
+function activateSatelliteExplorer(map, infoBox, overlay) {
+    infoBox.update({ title: 'Satellite Explorer', description: 'Browse different satellite layers.' });
+
+    if (overlay) {
+        overlay.innerHTML = `
+            <div class="bg-gray-800 bg-opacity-80 p-4 rounded-lg pointer-events-auto">
+                <label for="satellite-select" class="block mb-2 text-white text-sm">Select Layer:</label>
+                <select id="satellite-select" class="text-black p-1 rounded">
+                    <option value="esri">Esri World Imagery</option>
+                    <option value="usgs">USGS Imagery</option>
+                </select>
+            </div>
+        `;
+        overlay.classList.remove('hidden');
+        overlay.classList.remove('pointer-events-none');
+    }
+
+    let currentLayer = map.satelliteLayer;
+
+    function setLayer(key) {
+        if (currentLayer) map.removeLayer(currentLayer);
+        const info = SATELLITE_LAYERS[key];
+        currentLayer = L.tileLayer(info.url, { attribution: info.attribution });
+        currentLayer.addTo(map);
+        map.satelliteLayer = currentLayer;
+    }
+
+    const selectEl = overlay ? overlay.querySelector('#satellite-select') : null;
+    if (selectEl) {
+        setLayer(selectEl.value);
+        selectEl.addEventListener('change', () => setLayer(selectEl.value));
+    }
+}
+
+window.activateSatelliteExplorer = activateSatelliteExplorer;


### PR DESCRIPTION
## Summary
- add `satellite.js` implementing selectable satellite imagery layers
- load the new script and update overlay handling
- trigger `activateSatelliteExplorer` when selecting *Satellite Explorer*

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6883a4fc048883249b637f7aa05675fe