### PR TITLE
Add floating control for satellite layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,5 +5,6 @@ A simple map-based dashboard using Leaflet and public APIs. It currently include
 - Real-Time Weather
 - Air Quality (AQI)
 - Storm Tracker
+- Satellite Explorer
 
 Open `index.html` in a browser to explore the map and dashboards.

--- a/satellite.js
+++ b/satellite.js
@@ -1,46 +1,57 @@
 const SATELLITE_LAYERS = {
     esri: {
+        name: 'Esri World Imagery',
         url: 'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}',
         attribution: '&copy; <a href="https://www.esri.com/">Esri</a>'
     },
     usgs: {
+        name: 'USGS Imagery',
         url: 'https://basemap.nationalmap.gov/ArcGIS/rest/services/USGSImageryOnly/MapServer/tile/{z}/{y}/{x}',
         attribution: 'Tiles courtesy of the <a href="https://usgs.gov/">USGS</a>'
     }
 };
 
+L.Control.SatelliteLayers = L.Control.extend({
+    options: {
+        position: 'topright'
+    },
+
+    onAdd: function(map) {
+        const container = L.DomUtil.create('div', 'leaflet-bar p-2 rounded bg-gray-800 bg-opacity-80');
+        L.DomEvent.disableClickPropagation(container);
+        const select = L.DomUtil.create('select', 'text-black p-1 rounded', container);
+
+        for (const key in SATELLITE_LAYERS) {
+            const opt = L.DomUtil.create('option', '', select);
+            opt.value = key;
+            opt.textContent = SATELLITE_LAYERS[key].name;
+        }
+
+        const setLayer = (key) => {
+            if (map.satelliteLayer) map.removeLayer(map.satelliteLayer);
+            const info = SATELLITE_LAYERS[key];
+            map.satelliteLayer = L.tileLayer(info.url, { attribution: info.attribution });
+            map.satelliteLayer.addTo(map);
+        };
+
+        select.addEventListener('change', () => setLayer(select.value));
+
+        // initialize first layer
+        setLayer(select.value);
+
+        return container;
+    }
+});
+
 function activateSatelliteExplorer(map, infoBox, overlay) {
     infoBox.update({ title: 'Satellite Explorer', description: 'Browse different satellite layers.' });
 
-    if (overlay) {
-        overlay.innerHTML = `
-            <div class="bg-gray-800 bg-opacity-80 p-4 rounded-lg pointer-events-auto">
-                <label for="satellite-select" class="block mb-2 text-white text-sm">Select Layer:</label>
-                <select id="satellite-select" class="text-black p-1 rounded">
-                    <option value="esri">Esri World Imagery</option>
-                    <option value="usgs">USGS Imagery</option>
-                </select>
-            </div>
-        `;
-        overlay.classList.remove('hidden');
-        overlay.classList.remove('pointer-events-none');
+    if (map.satelliteControl) {
+        map.removeControl(map.satelliteControl);
     }
 
-    let currentLayer = map.satelliteLayer;
-
-    function setLayer(key) {
-        if (currentLayer) map.removeLayer(currentLayer);
-        const info = SATELLITE_LAYERS[key];
-        currentLayer = L.tileLayer(info.url, { attribution: info.attribution });
-        currentLayer.addTo(map);
-        map.satelliteLayer = currentLayer;
-    }
-
-    const selectEl = overlay ? overlay.querySelector('#satellite-select') : null;
-    if (selectEl) {
-        setLayer(selectEl.value);
-        selectEl.addEventListener('change', () => setLayer(selectEl.value));
-    }
+    map.satelliteControl = new L.Control.SatelliteLayers();
+    map.addControl(map.satelliteControl);
 }
 
 window.activateSatelliteExplorer = activateSatelliteExplorer;


### PR DESCRIPTION
## Summary
- add bullet for Satellite Explorer in README
- use a custom Leaflet control for satellite layer selection
- remove overlay manipulation from satellite explorer activation

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_688542efd4888324a9a7a38afc1fd11b