### PR TITLE
Add precipitation map overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Map Dash is a small demo application that showcases several map-based dashboards
 ## Features
 
 - **Real-Time Weather** – fetches the current temperature and wind information from the [Open-Meteo](https://open-meteo.com/) API. A cloud cover layer from OpenWeatherMap can be displayed when an API key is provided.
+- **Precipitation Map** – overlays current cloud and rain data using OpenWeatherMap tiles.
 - **Satellite Explorer** – lets you switch between different satellite imagery sources such as Esri World Imagery and USGS.
 - **Air Quality (AQI)** – displays the current US AQI along with PM2.5 and PM10 levels using the Open-Meteo air quality API.
 - **Storm Tracker** – loads active weather alerts from the US National Weather Service and indicates how far the nearest alert is from the map center.
@@ -24,18 +25,19 @@ Map Dash is a small demo application that showcases several map-based dashboards
 
 ## Providing an OpenWeatherMap API Key
 
-Cloud imagery is optional. If you would like to enable it, edit `config.js` and set `OPENWEATHERMAP_API_KEY` to your OpenWeatherMap API key:
+Cloud imagery and precipitation overlays are optional. If you would like to enable them, edit `config.js` and set `OPENWEATHERMAP_API_KEY` to your OpenWeatherMap API key:
 
 ```javascript
 export const OPENWEATHERMAP_API_KEY = 'YOUR_KEY_HERE';
 ```
 
-Without an API key the weather dashboard still works but the cloud layer will be disabled.
+Without an API key the weather dashboard still works but the cloud and precipitation layers will be disabled.
 
 ## File Overview
 
 - `index.html` – main page with all UI controls and the Leaflet map setup.
 - `weather.js` – handles the real-time weather dashboard and optional cloud overlay.
+- `precipitation.js` – adds a layer showing clouds and rainfall using OpenWeatherMap.
 - `config.js` – stores your OpenWeatherMap API key used by `weather.js`.
 - `aqi.js` – logic for the air quality dashboard.
 - `storm.js` – fetches and displays storm alerts from the National Weather Service.
@@ -50,7 +52,7 @@ This project relies on the following services and libraries:
 - [Leaflet](https://leafletjs.com/) for interactive mapping
 - [Tailwind CSS](https://tailwindcss.com/) for styling
 - [Open-Meteo](https://open-meteo.com/) for weather and air quality data
-- [OpenWeatherMap](https://openweathermap.org/) for optional cloud cover tiles
+ - [OpenWeatherMap](https://openweathermap.org/) for optional cloud and precipitation tiles
 - [US National Weather Service](https://www.weather.gov/) for storm alerts
 - Various map tile providers such as Esri, USGS and EOX
 

--- a/index.html
+++ b/index.html
@@ -138,6 +138,14 @@
                     </svg>
                     <span>Real-Time Weather</span>
                 </button>
+                <!-- Precipitation Map -->
+                <button class="dashboard-btn flex items-center w-full p-3 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors text-left">
+                    <!-- Raindrop Icon -->
+                    <svg class="w-6 h-6 mr-3 text-blue-300" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
+                        <path stroke-linecap="round" stroke-linejoin="round" d="M12 2.25s-5.25 5.034-5.25 9.25a5.25 5.25 0 0010.5 0c0-4.216-5.25-9.25-5.25-9.25z" />
+                    </svg>
+                    <span>Precipitation Map</span>
+                </button>
                 <!-- Satellite Explorer -->
                 <button class="dashboard-btn flex items-center w-full p-3 bg-gray-700 hover:bg-gray-600 rounded-lg transition-colors text-left">
                     <!-- Satellite Dish Icon -->
@@ -183,6 +191,7 @@
     </footer>
 
     <script type="module" src="weather.js"></script>
+    <script type="module" src="precipitation.js"></script>
     <script src="aqi.js"></script>
     <script src="storm.js"></script>
     <script src="satellite.js"></script>
@@ -306,6 +315,9 @@
                 if (dashboardTitle === 'Real-Time Weather') {
                     hideOverlay();
                     activateWeather(map, infoBox, overlayEl);
+                } else if (dashboardTitle === 'Precipitation Map') {
+                    hideOverlay();
+                    activatePrecipitation(map, infoBox, overlayEl);
                 } else if (dashboardTitle === 'Air Quality (AQI)') {
                     hideOverlay();
                     activateAQI(map, infoBox, overlayEl);

--- a/precipitation.js
+++ b/precipitation.js
@@ -1,0 +1,42 @@
+import { OPENWEATHERMAP_API_KEY } from './config.js';
+
+function addCloudLayer(map) {
+    if (!OPENWEATHERMAP_API_KEY) return null;
+    if (map.cloudLayer) return map.cloudLayer;
+    map.cloudLayer = L.tileLayer(
+        `https://tile.openweathermap.org/map/clouds_new/{z}/{x}/{y}.png?appid=${OPENWEATHERMAP_API_KEY}`,
+        {
+            opacity: 0.5,
+            attribution: '&copy; <a href="https://openweathermap.org/">OpenWeatherMap</a>'
+        }
+    ).addTo(map);
+    return map.cloudLayer;
+}
+
+function addPrecipitationLayer(map) {
+    if (!OPENWEATHERMAP_API_KEY) return null;
+    if (map.precipLayer) return map.precipLayer;
+    map.precipLayer = L.tileLayer(
+        `https://tile.openweathermap.org/map/precipitation_new/{z}/{x}/{y}.png?appid=${OPENWEATHERMAP_API_KEY}`,
+        {
+            opacity: 0.5,
+            attribution: '&copy; <a href="https://openweathermap.org/">OpenWeatherMap</a>'
+        }
+    ).addTo(map);
+    return map.precipLayer;
+}
+
+function activatePrecipitation(map, infoBox, overlay) {
+    addCloudLayer(map);
+    addPrecipitationLayer(map);
+
+    const desc = 'Displaying cloud and precipitation layers.';
+    infoBox.update({ title: 'Precipitation Map', description: desc });
+
+    if (overlay) {
+        overlay.innerHTML = desc;
+        overlay.classList.remove('hidden');
+    }
+}
+
+window.activatePrecipitation = activatePrecipitation;


### PR DESCRIPTION
## Summary
- implement precipitation overlay using OpenWeatherMap tiles
- add 'Precipitation Map' dashboard option
- document new feature and update API key instructions

## Testing
- `node -e "import('./precipitation.js').then(()=>console.log('loaded'))"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688d3e0fa1648324990525ec24090705